### PR TITLE
Start and stop work reminders

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -67,3 +67,25 @@
       - media_player.bedroom
       - media_player.living_room
     service: tts.google_translate_say
+- id: '1575102185396'
+  alias: Time to stop work
+  description: ''
+  trigger:
+  - at: '17:00'
+    platform: time
+  condition:
+    condition: time
+    weekday:
+      - mon
+      - tue
+      - wed
+      - thu
+      - fri
+  action:
+  - alias: ''
+    data:
+      message: Time to stop work
+    entity_id:
+      - media_player.bedroom
+      - media_player.living_room
+    service: tts.google_translate_say

--- a/automations.yaml
+++ b/automations.yaml
@@ -45,3 +45,25 @@
     entity_id:
       - media_player.living_room
     service: tts.google_translate_say
+- id: '1575102185395'
+  alias: Time to start work
+  description: ''
+  trigger:
+  - at: '9:00'
+    platform: time
+  condition:
+    condition: time
+    weekday:
+      - mon
+      - tue
+      - wed
+      - thu
+      - fri
+  action:
+  - alias: ''
+    data:
+      message: Time to start work
+    entity_id:
+      - media_player.bedroom
+      - media_player.living_room
+    service: tts.google_translate_say


### PR DESCRIPTION
It's too easy to work all day when you don't leave the house. This makes sure I know when working hours are.